### PR TITLE
Fixed memory leak in evaluateError.

### DIFF
--- a/tsne_core.cpp
+++ b/tsne_core.cpp
@@ -386,6 +386,7 @@ T TSNE<T, OUTDIM>::evaluateError(unsigned int* row_P, unsigned int* col_P, T* va
     }
 
     // Clean up memory
+    delete tree;
     return C;
 }
 


### PR DESCRIPTION
Very simple change to prevent a memory leak that affected very large datasets, or very long runs of bhtsne.
